### PR TITLE
update qetag.js replace deprecated api

### DIFF
--- a/qetag.js
+++ b/qetag.js
@@ -65,7 +65,7 @@ function getEtag(buffer,callback){
 		}
 
 		sha1Buffer = Buffer.concat(
-			[new Buffer([prefix]),sha1Buffer],
+			[Buffer.from([prefix]),sha1Buffer],
 			sha1Buffer.length + 1
 		);
 


### PR DESCRIPTION
DeprecationWarning: Buffer() is deprecated due to security and usability issues